### PR TITLE
Fix testing new features instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,6 @@ Algebraeon is organized as a [cargo workspace](https://doc.rust-lang.org/book/ch
 
 A suggested workflow for testing new features:
  - Create a new binary in `examples/src/bin`, for example `my_main.rs`.
- - To run, use `cargo run --bin my_main.rs` in the root directory.
+ - To run, use `cargo run --bin my_main` in the root directory.
  - Test any changes to the codebase with unit tests and/or using `my_main.rs`.
 


### PR DESCRIPTION
While trying the "testing new features" instruction, I got the following error:

```sh
$ cargo run --bin main_rings.rs
error: no bin target named `main_rings.rs`

	Did you mean `main_rings`?
```