### PR TITLE
Ideal factoring bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
  - Added database of Conway polynomials.
  - Added structure for finite fields using Conway polynomials and inclusion maps between finite fields.
+ - Fixed a bug in ring of integers multiplication in dimensions >= 3
 
 ## [0.0.12] - 2025-04-12
 

--- a/rings/src/number/anf/ideal.rs
+++ b/rings/src/number/anf/ideal.rs
@@ -20,7 +20,19 @@ impl RingOfIntegersWithIntegralBasisStructure {
             RingOfIntegersIdeal::NonZero { lattice } => {
                 assert_eq!(lattice.rows(), self.degree());
                 assert_eq!(lattice.cols(), 1);
-                //TODO: check that it's actually an ideal
+                // check it's actually an ideal
+                for ideal_basis_elem in lattice
+                    .basis_matrices()
+                    .into_iter()
+                    .map(|m| RingOfIntegersWithIntegralBasisElement::from_col(&m))
+                {
+                    for integral_basis_elem in (0..self.degree()).map(|i| {
+                        RingOfIntegersWithIntegralBasisElement::basis_element(self.degree(), i)
+                    }) {
+                        let x = self.mul(&ideal_basis_elem, &integral_basis_elem).into_col();
+                        assert!(lattice.contains_point(&x));
+                    }
+                }
             }
         }
     }
@@ -214,6 +226,9 @@ impl IdealArithmeticStructure for RingOfIntegersWithIntegralBasisStructure {
                     .into_iter()
                     .map(|m| RingOfIntegersWithIntegralBasisElement::from_col(&m))
                     .collect::<Vec<_>>();
+
+                debug_assert_eq!(a_basis.len(), n);
+                debug_assert_eq!(b_basis.len(), n);
 
                 let mut span = vec![];
                 for i in 0..n {

--- a/rings/src/number/anf/ideal.rs
+++ b/rings/src/number/anf/ideal.rs
@@ -106,7 +106,7 @@ impl IdealArithmeticStructure for RingOfIntegersWithIntegralBasisStructure {
             Self::Ideal::Zero
         } else {
             let n = self.degree();
-            self.ideal_from_integer_basis(
+            let ideal = self.ideal_from_integer_basis(
                 (0..n)
                     .map(|i| {
                         self.try_anf_to_roi(
@@ -115,7 +115,10 @@ impl IdealArithmeticStructure for RingOfIntegersWithIntegralBasisStructure {
                         .unwrap()
                     })
                     .collect(),
-            )
+            );
+            #[cfg(debug_assertions)]
+            self.check_ideal(&ideal);
+            ideal
         }
     }
 

--- a/rings/src/number/anf/ring_of_integers.rs
+++ b/rings/src/number/anf/ring_of_integers.rs
@@ -77,6 +77,10 @@ impl RingOfIntegersWithIntegralBasisStructure {
         self.integral_basis.len()
     }
 
+    pub fn integral_basis(&self) -> &Vec<Polynomial<Rational>> {
+        &self.integral_basis
+    }
+
     pub fn basis_element(&self, i: usize) -> &Polynomial<Rational> {
         assert!(i < self.degree());
         &self.integral_basis[i]

--- a/rings/src/number/anf/ring_of_integers.rs
+++ b/rings/src/number/anf/ring_of_integers.rs
@@ -260,16 +260,26 @@ impl SemiRingStructure for RingOfIntegersWithIntegralBasisStructure {
             Some(mul_crossterms) => {
                 // Used cached cross-terms
                 let mut t = self.zero();
-                for mut i in 0..n {
-                    for mut j in 0..n {
+                for i in 0..n {
+                    for j in 0..n {
                         let c = &a.coefficients[i] * &b.coefficients[j];
                         // Sort i and j for indexing into mul_crossterms which is a triangular array
-                        if j > i {
-                            (i, j) = (j, i)
-                        }
+                        let (i, j) = if j <= i { (i, j) } else { (j, i) };
                         t = self.add(&t, &mul_crossterms[i][j].clone().scalar_mul(&c));
                     }
                 }
+                debug_assert!(
+                    self.equal(
+                        &self
+                            .try_anf_to_roi(
+                                &self
+                                    .algebraic_number_field
+                                    .mul(&self.roi_to_anf(a), &self.roi_to_anf(b)),
+                            )
+                            .unwrap(),
+                        &t
+                    )
+                );
                 t
             }
             None => {
@@ -488,5 +498,25 @@ mod tests {
         }
 
         println!("{:?}", roi);
+    }
+
+    #[test]
+    fn ideal_factoring() {
+        // Construct the ring of integers Z[i]
+        let x = &Polynomial::<Rational>::var().into_ergonomic();
+        let anf = (x.pow(3) + x + 1).into_verbose().algebraic_number_field();
+        let roi = anf.ring_of_integers();
+
+        // The ideal (27i - 9) in Z[i]
+        let ideal = roi.principal_ideal(&roi.try_anf_to_roi(&(27 * x - 9).into_verbose()).unwrap());
+
+        // Factor the ideal
+        for (prime_ideal, power) in roi
+            .factor_ideal(&ideal)
+            .unwrap()
+            .into_prime_factors_and_powers()
+        {
+            println!("power = {power} prime_ideal_factor = {:?}", prime_ideal);
+        }
     }
 }

--- a/rings/src/structure/ideals.rs
+++ b/rings/src/structure/ideals.rs
@@ -223,6 +223,7 @@ pub trait DedekindDomainStructure: IdealArithmeticStructure {
         prime_ideal: &DedekindDomainPrimeIdeal<Self>,
         ideal: &Self::Ideal,
     ) -> Natural {
+        debug_assert!(!self.ideal_equal(prime_ideal.ideal(), &self.unit_ideal()));
         let mut k = Natural::ZERO;
         let mut prime_ideal_to_the_k_plus_one = prime_ideal.ideal().clone();
         while self.ideal_contains(&prime_ideal_to_the_k_plus_one, ideal) {


### PR DESCRIPTION
The root cause was a dodgy multiplication implementation for rings of integers. It was fine in dimensionans 1 and 2 but ,due to an indexing variable persisting and being modified through iterations of a for loop, it was incorrect in dimensions >= 3. Also added more debug asserts for ideal structures to catch future regressions.