### PR TITLE
refactor exponent conversion to use the new TryInto methods

### DIFF
--- a/rings/src/parsing/polynomial.rs
+++ b/rings/src/parsing/polynomial.rs
@@ -320,11 +320,8 @@ impl Expr {
                             return Err("Negative exponents not allowed in polynomials".to_string());
                         }
                         // Convert Integer to Natural for nat_pow
-                        let exp_f64: f64 = (&n.numerator).into();
-                        if exp_f64 < 0.0 || exp_f64 > (usize::MAX as f64) {
-                            panic!("Exponent out of range for usize conversion");
-                        }
-                        let exp_natural = Natural::from(exp_f64 as usize);
+                        let exp_usize: usize = (&n.numerator).try_into().expect("Exponent out of range for usize conversion");
+                        let exp_natural = Natural::from(exp_usize);
                         Ok(base.nat_pow(&exp_natural))
                     }
                     _ => Err("Exponents must be integer constants in polynomials".to_string()),
@@ -391,11 +388,8 @@ impl Expr {
                             return Err("Negative exponents not allowed in polynomials".to_string());
                         }
                         // Convert Integer to Natural for nat_pow
-                        let exp_f64: f64 = (&n.numerator).into();
-                        if exp_f64 < 0.0 || exp_f64 > (usize::MAX as f64) {
-                            panic!("Exponent out of range for usize conversion");
-                        }
-                        let exp_natural = Natural::from(exp_f64 as usize);
+                        let exp_usize: usize = (&n.numerator).try_into().expect("Exponent out of range for usize conversion");
+                        let exp_natural = Natural::from(exp_usize);
                         Ok(base.nat_pow(&exp_natural))
                     }
                     _ => Err("Exponents must be integer constants in polynomials".to_string()),
@@ -494,11 +488,9 @@ impl Expr {
                                 if let Expr::Num(exp) = pow.exponent.as_ref() {
                                     if exp.denominator == Integer::from(1) {
                                         // Convert the Integer to usize safely
-                                        let exp_f64: f64 = (&exp.numerator).into();
-                                        if exp_f64 < 0.0 || exp_f64 > (usize::MAX as f64) {
-                                            panic!("Exponent out of range for usize conversion");
-                                        }
-                                        let degree = 1 + exp_f64 as usize;
+                                        let exp_usize: usize = (&exp.numerator).try_into()
+                                            .expect("Exponent out of range for usize conversion");
+                                        let degree = 1 + exp_usize;
                                         *terms.entry(degree).or_insert(Integer::from(0)) +=
                                             coefficient;
                                     }
@@ -513,11 +505,9 @@ impl Expr {
                                 if let Expr::Num(exp) = pow.exponent.as_ref() {
                                     if exp.denominator == Integer::from(1) {
                                         // Convert the Integer to usize safely
-                                        let exp_f64: f64 = (&exp.numerator).into();
-                                        if exp_f64 < 0.0 || exp_f64 > (usize::MAX as f64) {
-                                            panic!("Exponent out of range for usize conversion");
-                                        }
-                                        let degree = 1 + exp_f64 as usize;
+                                        let exp_usize: usize = (&exp.numerator).try_into()
+                                            .expect("Exponent out of range for usize conversion");
+                                        let degree = 1 + exp_usize;
                                         *terms.entry(degree).or_insert(Integer::from(0)) +=
                                             coefficient;
                                     }
@@ -551,11 +541,8 @@ impl Expr {
                         if let Expr::Num(exp) = p.exponent.as_ref() {
                             if exp.denominator == Integer::from(1) {
                                 // Convert the Integer to usize safely
-                                let exp_f64: f64 = (&exp.numerator).into();
-                                if exp_f64 < 0.0 || exp_f64 > (usize::MAX as f64) {
-                                    panic!("Exponent out of range for usize conversion");
-                                }
-                                let degree = exp_f64 as usize;
+                                let degree: usize = (&exp.numerator).try_into()
+                                    .expect("Exponent out of range for usize conversion");
                                 *terms.entry(degree).or_insert(Integer::from(0)) += coefficient;
                             } else {
                                 panic!("Fractional exponent in integer polynomial");
@@ -586,12 +573,10 @@ impl Expr {
                                 result_terms.insert(0, Integer::from(1)); // Start with x^0 = 1
 
                                 // Convert the Integer to usize safely
-                                let exp_f64: f64 = (&exp.numerator).into();
-                                if exp_f64 < 0.0 || exp_f64 > (usize::MAX as f64) {
-                                    panic!("Exponent out of range for usize conversion");
-                                }
+                                let exp_usize: usize = (&exp.numerator).try_into()
+                                    .expect("Exponent out of range for usize conversion");
 
-                                for _ in 0..exp_f64 as usize {
+                                for _ in 0..exp_usize {
                                     let mut new_result: HashMap<usize, Integer> = HashMap::new();
                                     for (res_deg, res_coef) in &result_terms {
                                         for (term_deg, term_coef) in &temp_terms {
@@ -677,11 +662,9 @@ impl Expr {
                                 if let Expr::Num(exp) = pow.exponent.as_ref() {
                                     if exp.denominator == Integer::from(1) {
                                         // Convert the Integer to usize safely
-                                        let exp_f64: f64 = (&exp.numerator).into();
-                                        if exp_f64 < 0.0 || exp_f64 > (usize::MAX as f64) {
-                                            panic!("Exponent out of range for usize conversion");
-                                        }
-                                        let degree = 1 + exp_f64 as usize;
+                                        let exp_usize: usize = (&exp.numerator).try_into()
+                                            .expect("Exponent out of range for usize conversion");
+                                        let degree = 1 + exp_usize;
                                         *terms.entry(degree).or_insert(Rational::from(0)) +=
                                             coefficient;
                                     }
@@ -696,11 +679,9 @@ impl Expr {
                                 if let Expr::Num(exp) = pow.exponent.as_ref() {
                                     if exp.denominator == Integer::from(1) {
                                         // Convert the Integer to usize safely
-                                        let exp_f64: f64 = (&exp.numerator).into();
-                                        if exp_f64 < 0.0 || exp_f64 > (usize::MAX as f64) {
-                                            panic!("Exponent out of range for usize conversion");
-                                        }
-                                        let degree = 1 + exp_f64 as usize;
+                                        let exp_usize: usize = (&exp.numerator).try_into()
+                                            .expect("Exponent out of range for usize conversion");
+                                        let degree = 1 + exp_usize;
                                         *terms.entry(degree).or_insert(Rational::from(0)) +=
                                             coefficient;
                                     }
@@ -734,11 +715,8 @@ impl Expr {
                         if let Expr::Num(exp) = p.exponent.as_ref() {
                             if exp.denominator == Integer::from(1) {
                                 // Convert the Integer to usize safely
-                                let exp_f64: f64 = (&exp.numerator).into();
-                                if exp_f64 < 0.0 || exp_f64 > (usize::MAX as f64) {
-                                    panic!("Exponent out of range for usize conversion");
-                                }
-                                let degree = exp_f64 as usize;
+                                let degree: usize = (&exp.numerator).try_into()
+                                    .expect("Exponent out of range for usize conversion");
                                 *terms.entry(degree).or_insert(Rational::from(0)) += coefficient;
                             } else {
                                 panic!("Fractional exponent in polynomial");
@@ -771,12 +749,10 @@ impl Expr {
                                 let mut result_terms: HashMap<usize, Rational> = HashMap::new();
                                 result_terms.insert(0, Rational::from(1)); // Start with x^0 = 1
 
-                                let exp_f64: f64 = (&exp.numerator).into();
-                                if exp_f64 < 0.0 || exp_f64 > (usize::MAX as f64) {
-                                    panic!("Exponent out of range for usize conversion");
-                                }
+                                let exp_usize: usize = (&exp.numerator).try_into()
+                                    .expect("Exponent out of range for usize conversion");
 
-                                for _ in 0..exp_f64 as usize {
+                                for _ in 0..exp_usize {
                                     let mut new_result: HashMap<usize, Rational> = HashMap::new();
                                     for (res_deg, res_coef) in &result_terms {
                                         for (term_deg, term_coef) in &temp_terms {


### PR DESCRIPTION
The changes replace the previous approach of converting to `f64` and then to `usize` with a safer and more direct use of `try_into`. eliminates unnecessary floating-point conversions
