### PR TITLE
[done with AI] Add latex and typst methods to Natural and Integer

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -25,7 +25,9 @@ jobs:
           ref: main
 
       - name: Run benchmark on main
-        run: cargo bench --bench library_benchmark -- --tolerance=0.99
+        run: |
+          cargo bench --bench library_benchmark -- --tolerance=0.99
+          git restore . # reset e.g. Cargo.lock
 
       - name: Checkout PR branch
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "rust-analyzer.check.command": "check"
+  "rust-analyzer.check.command": "clippy"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,12 +261,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
+name = "bincode-next"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "dbe9e7e6d14aeb39557f226bff158a30e367fac279d0e69b8b42fb41999f9a86"
 dependencies = [
  "serde",
+ "unty-next",
 ]
 
 [[package]]
@@ -870,11 +871,11 @@ dependencies = [
 
 [[package]]
 name = "gungraun"
-version = "0.17.2"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c1bbe46f51c63bc08a1fac0ee0c530a77c961613a86ecf828ab1b0ffc6687a"
+checksum = "7dcd6043b1ff8096c10cdd5c59930139b52ba63cbd1a3452bc3ff95d996f9334"
 dependencies = [
- "bincode",
+ "bincode-next",
  "derive_more",
  "gungraun-macros",
  "gungraun-runner",
@@ -882,12 +883,12 @@ dependencies = [
 
 [[package]]
 name = "gungraun-macros"
-version = "0.7.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdccd089c36fb2ee66ef0eb7b1baa3ce7e7878a8eae682d9c8c368869ff6eca1"
+checksum = "d7f3214bae6cfd6739f4f29edb262bae439c6393a7b7b12c4eeb96417c2e50df"
 dependencies = [
  "derive_more",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -898,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "gungraun-runner"
-version = "0.17.2"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da6487203fa53ae6b1c8fead642fe79a3199464b0dd1337635594d675a9ac05"
+checksum = "6965c4e60026245b5600b05ab4c4af5ae1eaf72b8ec5da86c9cc6af01258d8cc"
 dependencies = [
  "serde",
 ]
@@ -1850,22 +1851,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
  "syn 2.0.112",
@@ -2569,6 +2570,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unty-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa66022bbd1ab992fad72bdedcfd07a0023b6f5ecc83d50121e39e3a3caed41"
 
 [[package]]
 name = "version_check"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -399,9 +399,9 @@ fn expand_meta_trait(trait_item: &ItemTrait) -> proc_macro2::TokenStream {
                                             });
                                         }
                                     }
-                                    syn::Type::Path(type_path) => {
+                                    syn::Type::Path(type_path)
                                         // if the first argument is `a: Self::Elem` then replace it with `self` in the meta type (TODO)
-                                        if is_type_path_self_set(type_path) {
+                                        if is_type_path_self_set(type_path) => {
                                             meta_args[0] = PatIdent {
                                                 attrs: vec![],
                                                 by_ref: None,
@@ -426,7 +426,6 @@ fn expand_meta_trait(trait_item: &ItemTrait) -> proc_macro2::TokenStream {
                                                 })),
                                             });
                                         }
-                                    }
                                     _ => {}
                                 },
                             }

--- a/nzq/src/integer/mod.rs
+++ b/nzq/src/integer/mod.rs
@@ -286,6 +286,14 @@ impl Integer {
     pub const ONE: Self = Self(malachite_nz::integer::Integer::ONE);
     pub const TWO: Self = Self(malachite_nz::integer::Integer::TWO);
 
+    pub fn latex(&self) -> String {
+        format!("{}", self)
+    }
+
+    pub fn typst(&self) -> String {
+        format!("{}", self)
+    }
+
     pub fn sqrt_if_square(&self) -> Option<Natural> {
         if self < &Integer::ZERO {
             None
@@ -670,6 +678,20 @@ impl CountableSetSignature for IntegerCanonicalStructure {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_latex_and_typst() {
+        assert_eq!(Integer::ZERO.latex(), "0");
+        assert_eq!(Integer::ZERO.typst(), "0");
+
+        let i = Integer::from(42);
+        assert_eq!(i.latex(), "42");
+        assert_eq!(i.typst(), "42");
+
+        let neg = Integer::from(-5);
+        assert_eq!(neg.latex(), "-5");
+        assert_eq!(neg.typst(), "-5");
+    }
 
     #[test]
     fn test_int_to_uint() {

--- a/nzq/src/natural/mod.rs
+++ b/nzq/src/natural/mod.rs
@@ -146,6 +146,14 @@ impl Natural {
     pub const ZERO: Self = Self(malachite_nz::natural::Natural::ZERO);
     pub const ONE: Self = Self(malachite_nz::natural::Natural::ONE);
     pub const TWO: Self = Self(malachite_nz::natural::Natural::TWO);
+
+    pub fn latex(&self) -> String {
+        format!("{}", self)
+    }
+
+    pub fn typst(&self) -> String {
+        format!("{}", self)
+    }
 }
 
 impl AddAssign<Natural> for Natural {
@@ -782,6 +790,16 @@ impl CountableSetSignature for NaturalCanonicalStructure {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_latex_and_typst() {
+        assert_eq!(Natural::ZERO.latex(), "0");
+        assert_eq!(Natural::ZERO.typst(), "0");
+
+        let n = Natural::from(42u32);
+        assert_eq!(n.latex(), "42");
+        assert_eq!(n.typst(), "42");
+    }
 
     #[test]
     fn test_nat_to_usize() {

--- a/nzq/src/rational/mod.rs
+++ b/nzq/src/rational/mod.rs
@@ -240,7 +240,7 @@ impl Rational {
     pub const TWO: Self = Self(malachite_q::Rational::TWO);
     pub const ONE_HALF: Self = Self(malachite_q::Rational::ONE_HALF);
 
-    fn latex(&self) -> String {
+    pub fn latex(&self) -> String {
         let (num, den) = self.numerator_and_denominator();
         if den == Natural::ONE {
             format!("{}", num)
@@ -249,7 +249,7 @@ impl Rational {
         }
     }
 
-    fn typst(&self) -> String {
+    pub fn typst(&self) -> String {
         let (num, den) = self.numerator_and_denominator();
         if den == Natural::ONE {
             format!("{}", num)
@@ -874,6 +874,11 @@ mod tests {
         let r4 = Rational::from_integers(-2, 4);
         assert_eq!(r4.latex(), "\\frac{-1}{2}");
         assert_eq!(r4.typst(), "-1/2");
+
+        // a negative denominator is normalised away
+        let r5 = Rational::from_integers(2, -3);
+        assert_eq!(r5.latex(), "\\frac{-2}{3}");
+        assert_eq!(r5.typst(), "-2/3");
     }
 
     #[test]


### PR DESCRIPTION
Follows the pattern from #91 for Rational. Also makes Rational::latex and Rational::typst public (they were private and only reachable from tests) and adds a test showing that negative denominators are normalised away.

Part of #31.