### PR TITLE
[done with AI] Accept Into<Set> in Matrix::diag

### DIFF
--- a/guide/src/matrices.md
+++ b/guide/src/matrices.md
@@ -16,7 +16,7 @@ assert_eq!(a.cols(), 3);
 
 let zero = Matrix::<Integer>::zero(2, 3);
 let ident = Matrix::<Integer>::ident(3);
-let diag = Matrix::<Integer>::diag(vec![1, 5, 9]);
+let diag = Matrix::<Integer>::diag(&vec![1, 5, 9]);
 
 assert_eq!(zero.rows(), 2);
 assert_eq!(ident.cols(), 3);

--- a/guide/src/matrices.md
+++ b/guide/src/matrices.md
@@ -16,7 +16,7 @@ assert_eq!(a.cols(), 3);
 
 let zero = Matrix::<Integer>::zero(2, 3);
 let ident = Matrix::<Integer>::ident(3);
-let diag = Matrix::<Integer>::diag(&[1, 5, 9].map(Integer::from));
+let diag = Matrix::<Integer>::diag(vec![1, 5, 9]);
 
 assert_eq!(zero.rows(), 2);
 assert_eq!(ident.cols(), 3);

--- a/rings/src/matrix/matrix.rs
+++ b/rings/src/matrix/matrix.rs
@@ -748,8 +748,17 @@ where
         Self::structure().ident(n)
     }
 
-    pub fn diag(diag: Vec<impl Into<R>>) -> Self {
-        Self::structure().diag(&diag.into_iter().map(Into::into).collect::<Vec<_>>())
+    /// Construct a diagonal matrix from a list of diagonal entries.
+    pub fn diag(diag: Vec<impl Into<R> + Clone>) -> Self {
+        let n = diag.len();
+        let structure = R::structure();
+        Self::construct(n, n, |r, c| {
+            if r == c {
+                diag[r].clone().into()
+            } else {
+                structure.zero()
+            }
+        })
     }
 
     pub fn dot(a: &Self, b: &Self) -> R {

--- a/rings/src/matrix/matrix.rs
+++ b/rings/src/matrix/matrix.rs
@@ -748,8 +748,8 @@ where
         Self::structure().ident(n)
     }
 
-    pub fn diag(diag: &[R]) -> Self {
-        Self::structure().diag(diag)
+    pub fn diag(diag: Vec<impl Into<R>>) -> Self {
+        Self::structure().diag(&diag.into_iter().map(Into::into).collect::<Vec<_>>())
     }
 
     pub fn dot(a: &Self, b: &Self) -> R {

--- a/rings/src/matrix/matrix.rs
+++ b/rings/src/matrix/matrix.rs
@@ -464,10 +464,11 @@ impl<RS: RingSignature, RSB: BorrowedStructure<RS>> MatrixStructure<RS, RSB> {
         })
     }
 
-    pub fn diag(&self, diag: &[RS::Elem]) -> Matrix<RS::Elem> {
-        Matrix::construct(diag.len(), diag.len(), |r, c| {
+    pub fn diag(&self, diag: &[impl Clone + Into<RS::Elem>]) -> Matrix<RS::Elem> {
+        let n = diag.len();
+        Matrix::construct(n, n, |r, c| {
             if r == c {
-                diag[r].clone()
+                diag[r].clone().into()
             } else {
                 self.ring().zero()
             }
@@ -749,16 +750,8 @@ where
     }
 
     /// Construct a diagonal matrix from a list of diagonal entries.
-    pub fn diag(diag: Vec<impl Into<R> + Clone>) -> Self {
-        let n = diag.len();
-        let structure = R::structure();
-        Self::construct(n, n, |r, c| {
-            if r == c {
-                diag[r].clone().into()
-            } else {
-                structure.zero()
-            }
-        })
+    pub fn diag(diag: &[impl Into<R> + Clone]) -> Self {
+        Self::structure().diag(diag)
     }
 
     pub fn dot(a: &Self, b: &Self) -> R {


### PR DESCRIPTION
Change the static Matrix::<R>::diag to take Vec<impl Into<R>> so it can be called with raw literals like diag(vec![1, 5, 9]), matching from_rows. Update the matrices guide example accordingly.