### PR TITLE
An approach to passing owned or borrowed arguments

### DIFF
--- a/rings/src/num_theory/integer_ideal.rs
+++ b/rings/src/num_theory/integer_ideal.rs
@@ -49,8 +49,16 @@ impl ZeroSignature for IntegerIdealsStructure {
 }
 
 impl AdditionSignature for IntegerIdealsStructure {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
-        gcd(a.clone(), b.clone())
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a,
+    {
+        gcd(a.into().into_owned(), b.into().into_owned())
     }
 }
 

--- a/rings/src/num_theory/integer_structure.rs
+++ b/rings/src/num_theory/integer_structure.rs
@@ -25,8 +25,21 @@ impl ZeroSignature for IntegerCanonicalStructure {
 }
 
 impl AdditionSignature for IntegerCanonicalStructure {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
-        a + b
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a,
+    {
+        match (a.into(), b.into()) {
+            (Arg::Borrowed(a), Arg::Borrowed(b)) => a + b,
+            (Arg::Borrowed(a), Arg::Owned(b)) => a + b,
+            (Arg::Owned(a), Arg::Borrowed(b)) => a + b,
+            (Arg::Owned(a), Arg::Owned(b)) => a + b,
+        }
     }
 }
 

--- a/rings/src/num_theory/modulo/const_naive.rs
+++ b/rings/src/num_theory/modulo/const_naive.rs
@@ -172,7 +172,17 @@ impl<const N: usize> ZeroSignature for ModuloCanonicalStructure<N> {
 }
 
 impl<const N: usize> AdditionSignature for ModuloCanonicalStructure<N> {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a,
+    {
+        let a = a.into();
+        let b = b.into();
         Modulo { x: (a.x + b.x) % N }
     }
 }

--- a/rings/src/num_theory/modulo/montgomery.rs
+++ b/rings/src/num_theory/modulo/montgomery.rs
@@ -187,11 +187,22 @@ impl ZeroSignature for MontgomeryModuloOddStructure {
 }
 
 impl AdditionSignature for MontgomeryModuloOddStructure {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a,
+    {
+        let a = a.into().into_owned();
+        let b = b.into().into_owned();
+
         #[cfg(debug_assertions)]
         {
-            self.validate_element(a).unwrap();
-            self.validate_element(b).unwrap();
+            self.validate_element(&a).unwrap();
+            self.validate_element(&b).unwrap();
         }
         let s = a + b;
         let s = if s >= self.n { s - self.n } else { s };
@@ -395,7 +406,15 @@ impl ZeroSignature for MontgomeryModuloOddPrimeStructure {
 }
 
 impl AdditionSignature for MontgomeryModuloOddPrimeStructure {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a,
+    {
         self.sup.add(a, b)
     }
 }

--- a/rings/src/num_theory/natural_structure.rs
+++ b/rings/src/num_theory/natural_structure.rs
@@ -12,8 +12,21 @@ impl ZeroSignature for NaturalCanonicalStructure {
 }
 
 impl AdditionSignature for NaturalCanonicalStructure {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
-        a + b
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a,
+    {
+        match (a.into(), b.into()) {
+            (Arg::Borrowed(a), Arg::Borrowed(b)) => a + b,
+            (Arg::Borrowed(a), Arg::Owned(b)) => a + b,
+            (Arg::Owned(a), Arg::Borrowed(b)) => a + b,
+            (Arg::Owned(a), Arg::Owned(b)) => a + b,
+        }
     }
 }
 

--- a/rings/src/polynomial/hensel_lifting_btree.rs
+++ b/rings/src/polynomial/hensel_lifting_btree.rs
@@ -490,8 +490,8 @@ impl<RS: EuclideanDomainSignature + GreatestCommonDivisorSignature + FactoringMo
 
                 f_factorization.h = lifted_f;
                 g_factorization.h = lifted_g;
-                *a = pring_mod_i2n.add(a, &delta_a);
-                *b = pring_mod_i2n.add(b, &delta_b);
+                *a = pring_mod_i2n.add(&*a, &delta_a);
+                *b = pring_mod_i2n.add(&*b, &delta_b);
 
                 f_factorization.quadratic_lift(ring, i, n);
                 g_factorization.quadratic_lift(ring, i, n);

--- a/rings/src/polynomial/multipoly_structure.rs
+++ b/rings/src/polynomial/multipoly_structure.rs
@@ -99,8 +99,21 @@ impl<RS: RingEqSignature> ZeroSignature for MultiPolynomialStructure<RS> {
 }
 
 impl<RS: RingEqSignature> AdditionSignature for MultiPolynomialStructure<RS> {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
-        let mut a = a.clone();
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a,
+    {
+        let (mut a, b) = match (a.into(), b.into()) {
+            (Arg::Borrowed(a), Arg::Borrowed(b)) => (a.clone(), Arg::Borrowed(b)),
+            (Arg::Owned(a), b) => (a, b),
+            (a, Arg::Owned(b)) => (b, a),
+        };
+
         let mut existing_monomials: HashMap<Monomial, usize> = HashMap::new(); //the index of each monomial
         for (
             idx,

--- a/rings/src/polynomial/polynomial_structure.rs
+++ b/rings/src/polynomial/polynomial_structure.rs
@@ -362,8 +362,16 @@ impl<RS: SemiRingEqSignature> ZeroSignature for PolynomialStructure<RS> {
 }
 
 impl<RS: SemiRingEqSignature> AdditionSignature for PolynomialStructure<RS> {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
-        self.add_impl(a, b)
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a,
+    {
+        self.add_impl(&a.into(), &b.into())
     }
 }
 

--- a/rings/src/quaternion_algebra/mod.rs
+++ b/rings/src/quaternion_algebra/mod.rs
@@ -121,7 +121,17 @@ impl<Field: FieldSignature> ZeroSignature for QuaternionAlgebraStructure<Field> 
 }
 
 impl<Field: FieldSignature> AdditionSignature for QuaternionAlgebraStructure<Field> {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a,
+    {
+        let a = a.into();
+        let b = b.into();
         QuaternionAlgebraElement {
             x: self.base.add(&a.x, &b.x),
             y: self.base.add(&a.y, &b.y),

--- a/rings/src/quaternion_algebra/quaternion_orders.rs
+++ b/rings/src/quaternion_algebra/quaternion_orders.rs
@@ -102,7 +102,15 @@ impl<ANF: AlgebraicNumberFieldSignature> ZeroSignature for QuaternionOrderZBasis
 }
 
 impl<ANF: AlgebraicNumberFieldSignature> AdditionSignature for QuaternionOrderZBasis<ANF> {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a,
+    {
         self.algebra.add(a, b)
     }
 }

--- a/rings/src/rational.rs
+++ b/rings/src/rational.rs
@@ -28,8 +28,20 @@ impl ZeroSignature for RationalCanonicalStructure {
 }
 
 impl AdditionSignature for RationalCanonicalStructure {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
-        a + b
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self::Elem: 'a,
+    {
+        match (a.into(), b.into()) {
+            (Arg::Borrowed(a), Arg::Borrowed(b)) => a + b,
+            (Arg::Borrowed(a), Arg::Owned(b)) => a + b,
+            (Arg::Owned(a), Arg::Borrowed(b)) => a + b,
+            (Arg::Owned(a), Arg::Owned(b)) => a + b,
+        }
     }
 }
 

--- a/rings/src/structure/euclidean_quotient.rs
+++ b/rings/src/structure/euclidean_quotient.rs
@@ -201,7 +201,15 @@ impl<RS: EuclideanDomainSignature, const IS_FIELD: bool> ZeroSignature
 impl<RS: EuclideanDomainSignature, const IS_FIELD: bool> AdditionSignature
     for EuclideanRemainderQuotientStructure<RS, IS_FIELD>
 {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a,
+    {
         self.ring().rem(&self.ring().add(a, b), &self.modulus)
     }
 }

--- a/rings/src/structure/factorization.rs
+++ b/rings/src/structure/factorization.rs
@@ -211,7 +211,7 @@ impl<
                             for (a_p, a_k) in &mut a.powers {
                                 debug_assert!(self.objects().is_fav_assoc(a_p));
                                 if self.objects().equal(a_p, b_p) {
-                                    *a_k = self.exponents().add(a_k, b_k);
+                                    *a_k = self.exponents().add(&*a_k, b_k);
                                     break 'A_LOOP;
                                 }
                             }

--- a/rings/src/structure/homomorphisms.rs
+++ b/rings/src/structure/homomorphisms.rs
@@ -97,7 +97,15 @@ mod range_module {
     impl<Domain: RingSignature, Range: RingSignature, Hom: RingHomomorphism<Domain, Range>>
         AdditionSignature for RingHomomorphismRangeModuleStructure<Domain, Range, Hom>
     {
-        fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem {
+        fn add<'a>(
+            self: &Arc<Self>,
+            a: impl Into<Arg<'a, Self::Elem>>,
+            b: impl Into<Arg<'a, Self::Elem>>,
+        ) -> Self::Elem
+        where
+            Self: 'a,
+            Self::Elem: 'a,
+        {
             self.hom.range().add(a, b)
         }
     }

--- a/rings/src/structure/rings.rs
+++ b/rings/src/structure/rings.rs
@@ -75,7 +75,14 @@ mod unconstructable_universal_structure {
     }
 
     impl<Set: Debug + Clone + Send + Sync> AdditionSignature for UnconstructableStructure<Set> {
-        fn add(self: &Arc<Self>, _a: &Self::Elem, _b: &Self::Elem) -> Self::Elem {
+        fn add<'a>(
+            self: &Arc<Self>,
+            _a: impl Into<Arg<'a, Self::Elem>>,
+            _b: impl Into<Arg<'a, Self::Elem>>,
+        ) -> Self::Elem
+        where
+            Self::Elem: 'a,
+        {
             unreachable!()
         }
     }
@@ -201,10 +208,17 @@ pub trait ZeroSignature: RinglikeSpecializationSignature {
 /// A set with an associative commutative binary operation of addition.
 #[signature_meta_trait]
 pub trait AdditionSignature: RinglikeSpecializationSignature {
-    fn add(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Self::Elem;
+    fn add<'a>(
+        self: &Arc<Self>,
+        a: impl Into<Arg<'a, Self::Elem>>,
+        b: impl Into<Arg<'a, Self::Elem>>,
+    ) -> Self::Elem
+    where
+        Self: 'a,
+        Self::Elem: 'a;
 
     fn add_mut(self: &Arc<Self>, a: &mut Self::Elem, b: &Self::Elem) {
-        *a = self.add(a, b);
+        *a = self.add(&*a, b);
     }
 }
 

--- a/sets/src/sets/empty.rs
+++ b/sets/src/sets/empty.rs
@@ -28,9 +28,9 @@ impl<Elem> Default for EmptySetStructure<Elem> {
     }
 }
 
-impl<Elem: Clone + Send + Sync> Signature for EmptySetStructure<Elem> {}
+impl<Elem: Clone + Send + Sync + 'static> Signature for EmptySetStructure<Elem> {}
 
-impl<Elem: Debug + Clone + Send + Sync> SetSignature for EmptySetStructure<Elem> {
+impl<Elem: Debug + Clone + Send + Sync + 'static> SetSignature for EmptySetStructure<Elem> {
     type Elem = Elem;
 
     fn validate_element(self: &Arc<Self>, _: &Self::Elem) -> Result<(), String> {
@@ -38,19 +38,19 @@ impl<Elem: Debug + Clone + Send + Sync> SetSignature for EmptySetStructure<Elem>
     }
 }
 
-impl<Elem: Debug + Clone + Send + Sync> EqSignature for EmptySetStructure<Elem> {
+impl<Elem: Debug + Clone + Send + Sync + 'static> EqSignature for EmptySetStructure<Elem> {
     fn equal(self: &Arc<Self>, _: &Self::Elem, _: &Self::Elem) -> bool {
         panic!("Empty set had no elements to compare for equality")
     }
 }
 
-impl<Elem: Debug + Clone + Send + Sync> PartialOrdSignature for EmptySetStructure<Elem> {
+impl<Elem: Debug + Clone + Send + Sync + 'static> PartialOrdSignature for EmptySetStructure<Elem> {
     fn partial_cmp(self: &Arc<Self>, a: &Self::Elem, b: &Self::Elem) -> Option<std::cmp::Ordering> {
         Some(self.cmp(a, b))
     }
 }
 
-impl<Elem: Debug + Clone + Send + Sync> OrdSignature for EmptySetStructure<Elem> {
+impl<Elem: Debug + Clone + Send + Sync + 'static> OrdSignature for EmptySetStructure<Elem> {
     fn cmp(self: &Arc<Self>, _: &Self::Elem, _: &Self::Elem) -> std::cmp::Ordering {
         panic!("Empty set had no elements to compare for ordering")
     }

--- a/structures/src/sets/set.rs
+++ b/structures/src/sets/set.rs
@@ -1,5 +1,4 @@
 use crate::*;
-
 use algebraeon_macros::{signature_meta_trait, skip_meta};
 use paste::paste;
 use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};

--- a/structures/src/signatures/signature.rs
+++ b/structures/src/signatures/signature.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::*;
 
 /// For anything which is a structure type
@@ -9,3 +11,55 @@ impl<S, BS: Borrow<S> + Clone + Debug + Send + Sync> BorrowedElem<S> for BS {}
 // /// Helper for borrowing a structure type
 // pub trait BorrowedStructure<S: Signature>: Borrow<S> + Clone + Debug + Eq + Send + Sync {}
 // impl<S: Signature, BS: Borrow<S> + Clone + Debug + Eq + Send + Sync> BorrowedStructure<S> for BS {}
+
+pub enum Arg<'a, T> {
+    Borrowed(&'a T),
+    Owned(T),
+}
+
+impl<'a, T> From<T> for Arg<'a, T> {
+    fn from(value: T) -> Self {
+        Self::Owned(value)
+    }
+}
+
+impl<'a, T> From<&'a T> for Arg<'a, T> {
+    fn from(value: &'a T) -> Self {
+        Self::Borrowed(value)
+    }
+}
+
+impl<'a, T> From<&'a mut T> for Arg<'a, T> {
+    fn from(value: &'a mut T) -> Self {
+        Self::Borrowed(value)
+    }
+}
+
+impl<'a, T> AsRef<T> for Arg<'a, T> {
+    fn as_ref(&self) -> &T {
+        match self {
+            Arg::Borrowed(value) => value,
+            Arg::Owned(value) => value,
+        }
+    }
+}
+
+impl<'a, T> Deref for Arg<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<'a, T> Arg<'a, T> {
+    pub fn into_owned(self) -> T
+    where
+        T: Clone,
+    {
+        match self {
+            Arg::Owned(x) => x,
+            Arg::Borrowed(x) => x.clone(),
+        }
+    }
+}


### PR DESCRIPTION
Generally arguments to functions are passed by reference and cloned if needed. The downside to this is some functions would be more efficient if they could take owned values. For the sake of example, consider an expression of the form `(x*y)+(z*w)`. In Algebraeon this would currently appear as `add(&mul(&x, &y), &mul(&z, &w))` because `add` and `mul` can only take values by reference. If `x, y, z, w` are Malachite `Integer`s then this isn't the most efficient. We'd rather write `add(mul(x, y), mul(z, w))`. Malachite has optimised versions of `+` and `*` for `Integer` when the inputs are owned values, but we are currently missing out on this in Algebraeon. This is just one example where passing by reference everywhere is costing performance.

In this PR I am experimenting with passing arguments using something like
```rust
pub enum Arg<'a, T> {
    Borrowed(&'a T),
    Owned(T),
}
```
to allow passing references or owned values to functions. I hope for this will make a noticeable improvement to benchmarks without making things more complex at all sites.

Other options are to have separate functions for passing values by reference or ownership, but with this approach the number of functions needed grows fast and things get messy. For example `add` would already need 4 variants.