### PR TITLE
Parse quaternions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
  - Added methods for working with the Hexacode, Tetracode, and Extended Binary Golay Code.
  - Moved all structure types into `Arc`s to simplify code.
  - Added Van-Hoeij knapsack algorithm for factoring integer polynomials.
+ - Added parsing of quaternion algebra elements from strings such as `"2+3i+5j-2k"`.
+ - Allowed implicit multiplication by a numeric coefficient when parsing, so that `"3x"` means `"3*x"`.
 
 ## [0.0.17] - 2026-03-06
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,7 +22,6 @@ All notable changes to this project will be documented in this file.
  - Added Van-Hoeij knapsack algorithm for factoring integer polynomials.
  - Added parsing of expressions in an algebra over a field, respecting the order of the factors of each product so that algebras with non-commutative multiplication are supported.
  - Added parsing of quaternion algebra elements from strings such as `"2+3i+5j-2k"`.
- - Allowed implicit multiplication by a numeric coefficient when parsing, so that `"3x"` means `"3*x"`.
 
 ## [0.0.17] - 2026-03-06
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
  - Added methods for working with the Hexacode, Tetracode, and Extended Binary Golay Code.
  - Moved all structure types into `Arc`s to simplify code.
  - Added Van-Hoeij knapsack algorithm for factoring integer polynomials.
+ - Added parsing of expressions in an algebra over a field, respecting the order of the factors of each product so that algebras with non-commutative multiplication are supported.
  - Added parsing of quaternion algebra elements from strings such as `"2+3i+5j-2k"`.
  - Allowed implicit multiplication by a numeric coefficient when parsing, so that `"3x"` means `"3*x"`.
 

--- a/guide/src/quaternion_algebras.md
+++ b/guide/src/quaternion_algebras.md
@@ -24,3 +24,30 @@ let k = h.mul(&i, &j);
 assert!(h.equal(&k, &h.k()));
 assert!(h.equal(&h.mul(&j, &i), &h.neg(&k)));
 ```
+
+Elements can also be written as strings and read with `parse_quaternion`. The factors of a product are multiplied in the order they are written, so `"i*j"` and `"j*i"` give different elements.
+
+```rust
+use algebraeon::structures::Rational;
+use algebraeon::rings::parsing::parse_quaternion;
+use algebraeon::rings::quaternion_algebra::QuaternionAlgebraStructure;
+use algebraeon::rings::structure::*;
+use algebraeon::structures::{EqSignature, MetaType};
+
+let h = QuaternionAlgebraStructure::new(
+    Rational::structure(),
+    -Rational::ONE,
+    -Rational::TWO,
+);
+
+let q = parse_quaternion("2 + 3i + 5j - 2k", &h).unwrap();
+assert!(h.equal(&q, &h.from_components(
+    Rational::from(2),
+    Rational::from(3),
+    Rational::from(5),
+    Rational::from(-2),
+)));
+
+assert!(h.equal(&parse_quaternion("i*j", &h).unwrap(), &h.k()));
+assert!(h.equal(&parse_quaternion("j*i", &h).unwrap(), &h.neg(&h.k())));
+```

--- a/rings/src/parsing/algebra.rs
+++ b/rings/src/parsing/algebra.rs
@@ -34,7 +34,7 @@ pub fn parse_algebra_expression<
     algebra: &Arc<Algebra>,
     variables: &HashMap<&str, Algebra::Elem>,
 ) -> Result<Algebra::Elem, String> {
-    let expression = parse_expression(expression_str)?;
+    let expression = parse_expression(expression_str, true)?;
     expression.validate()?;
     evaluate(&expression, algebra, variables)
 }

--- a/rings/src/parsing/algebra.rs
+++ b/rings/src/parsing/algebra.rs
@@ -1,0 +1,110 @@
+use crate::parsing::ast::*;
+use crate::parsing::polynomial::parse_expression;
+use crate::structure::{FieldSignature, RingSignature, SemiModuleSignature};
+use algebraeon_structures::*;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Evaluate a string such as `"2 + 3i + 5j - 2k"` in an algebra over a field, given the value of
+/// each variable appearing in it.
+///
+/// Unlike parsing into a polynomial, the order of the factors of each product is preserved, so
+/// this works for algebras with non-commutative multiplication such as quaternion algebras.
+///
+/// ```
+/// use algebraeon_rings::parsing::parse_algebra_expression;
+/// use algebraeon_rings::quaternion_algebra::QuaternionAlgebraStructure;
+/// use algebraeon_rings::structure::*;
+/// use algebraeon_structures::*;
+/// use std::collections::HashMap;
+///
+/// // Hamilton quaternion algebra: H = (-1, -1 / QQ)
+/// let h = QuaternionAlgebraStructure::new(Rational::structure(), -Rational::ONE, -Rational::ONE);
+/// let variables = HashMap::from([("u", h.i()), ("v", h.j())]);
+///
+/// // uv = -vu, so uv - vu = 2ij = 2k
+/// let value = parse_algebra_expression("u*v - v*u", &h, &variables).unwrap();
+/// assert!(h.equal(&value, &h.scalar_mul(&h.k(), &Rational::TWO)));
+/// ```
+pub fn parse_algebra_expression<
+    Field: FieldSignature,
+    Algebra: RingSignature + SemiModuleSignature<Field>,
+>(
+    expression_str: &str,
+    algebra: &Arc<Algebra>,
+    variables: &HashMap<&str, Algebra::Elem>,
+) -> Result<Algebra::Elem, String> {
+    let expression = parse_expression(expression_str)?;
+    expression.validate()?;
+    evaluate(&expression, algebra, variables)
+}
+
+fn evaluate<Field: FieldSignature, Algebra: RingSignature + SemiModuleSignature<Field>>(
+    expression: &Expr,
+    algebra: &Arc<Algebra>,
+    variables: &HashMap<&str, Algebra::Elem>,
+) -> Result<Algebra::Elem, String> {
+    match expression {
+        Expr::Var(v) => match variables.get(v.name.as_str()) {
+            Some(value) => Ok(value.clone()),
+            None => Err(format!("Variable '{}' has no value", v.name)),
+        },
+        Expr::Num(n) => {
+            let scalar = scalar(n, algebra)?;
+            Ok(algebra.scalar_mul(&algebra.one(), &scalar))
+        }
+        Expr::Sum(s) => {
+            let mut result = algebra.zero();
+            for term in &s.terms {
+                let value = evaluate(&term.term, algebra, variables)?;
+                result = if term.sign {
+                    algebra.add(&result, &value)
+                } else {
+                    algebra.sub(&result, &value)
+                };
+            }
+            Ok(result)
+        }
+        Expr::Product(p) => {
+            // Multiplication by a numeric coefficient is scalar multiplication. As well as being
+            // faster, this means that expressions which are linear in the variables can be
+            // evaluated in algebras whose multiplication is only partially implemented.
+            match (p.left.as_ref(), p.right.as_ref()) {
+                (Expr::Num(n), other) | (other, Expr::Num(n)) => {
+                    let scalar = scalar(n, algebra)?;
+                    Ok(algebra.scalar_mul(&evaluate(other, algebra, variables)?, &scalar))
+                }
+                (left, right) => Ok(algebra.mul(
+                    &evaluate(left, algebra, variables)?,
+                    &evaluate(right, algebra, variables)?,
+                )),
+            }
+        }
+        Expr::Power(p) => {
+            let base = evaluate(&p.base, algebra, variables)?;
+            match p.exponent.as_ref() {
+                // Validation has already checked that the exponent is a non-negative integer
+                Expr::Num(n) => {
+                    let exponent: usize = (&n.numerator)
+                        .try_into()
+                        .map_err(|_| format!("Exponent {} is too large", n.numerator))?;
+                    Ok(algebra.nat_pow(&base, &Natural::from(exponent)))
+                }
+                _ => Err("Exponents must be integer constants".to_string()),
+            }
+        }
+        Expr::Grouped(e) => evaluate(e, algebra, variables),
+    }
+}
+
+/// The value of a number in the base field of the algebra.
+fn scalar<Field: FieldSignature, Algebra: RingSignature + SemiModuleSignature<Field>>(
+    number: &Number,
+    algebra: &Arc<Algebra>,
+) -> Result<Field::Elem, String> {
+    let value = Rational::from_integers(number.numerator.clone(), number.denominator.clone());
+    algebra
+        .ring()
+        .try_from_rat(&value)
+        .ok_or_else(|| format!("No element of the base field is equal to {}", value))
+}

--- a/rings/src/parsing/algebra_tests.rs
+++ b/rings/src/parsing/algebra_tests.rs
@@ -1,0 +1,36 @@
+use crate::finite_fields::conway_finite_fields::ConwayFiniteFieldStructure;
+use crate::parsing::parse_algebra_expression;
+use crate::polynomial::{Polynomial, ToPolynomialSignature};
+use algebraeon_structures::*;
+use std::collections::HashMap;
+
+#[test]
+fn test_parse_algebra_expression_in_a_polynomial_ring() {
+    let polynomials = Rational::structure().polynomials();
+    let variables = HashMap::from([("x", polynomials.var())]);
+
+    let f = parse_algebra_expression("(x + 2)*(x - 2) + 1/2", &polynomials, &variables).unwrap();
+    let expected = Polynomial::from_coeffs(vec![
+        Rational::from_integers(-7, 2),
+        Rational::ZERO,
+        Rational::ONE,
+    ]);
+    assert!(polynomials.equal(&f, &expected));
+}
+
+#[test]
+fn test_parse_algebra_expression_unknown_variable() {
+    let polynomials = Rational::structure().polynomials();
+    let variables = HashMap::from([("x", polynomials.var())]);
+
+    assert!(parse_algebra_expression("x + y", &polynomials, &variables).is_err());
+}
+
+#[test]
+fn test_parse_algebra_expression_coefficient_not_in_base_field() {
+    let f5 = ConwayFiniteFieldStructure::new(5, 1).unwrap().polynomials();
+    let variables = HashMap::from([("x", f5.var())]);
+
+    // 1/5 does not exist in characteristic 5
+    assert!(parse_algebra_expression("1/5*x", &f5, &variables).is_err());
+}

--- a/rings/src/parsing/ast.rs
+++ b/rings/src/parsing/ast.rs
@@ -126,6 +126,27 @@ impl Expr {
         vars
     }
 
+    /// Whether any factors in the expression were juxtaposed rather than separated by "*".
+    pub fn contains_implicit_multiplication(&self) -> bool {
+        match self {
+            Expr::Var(_) | Expr::Num(_) => false,
+            Expr::Sum(s) => s
+                .terms
+                .iter()
+                .any(|term| term.term.contains_implicit_multiplication()),
+            Expr::Product(p) => {
+                p.implicit
+                    || p.left.contains_implicit_multiplication()
+                    || p.right.contains_implicit_multiplication()
+            }
+            Expr::Power(p) => {
+                p.base.contains_implicit_multiplication()
+                    || p.exponent.contains_implicit_multiplication()
+            }
+            Expr::Grouped(e) => e.contains_implicit_multiplication(),
+        }
+    }
+
     pub fn add_variables(&self, vars: &mut HashSet<String>) {
         match self {
             Expr::Var(v) => {
@@ -168,6 +189,8 @@ impl fmt::Display for Expr {
 pub struct Product {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
+    /// Whether the factors were juxtaposed, as in "3x", rather than separated by "*".
+    pub implicit: bool,
 }
 
 impl Product {

--- a/rings/src/parsing/mod.rs
+++ b/rings/src/parsing/mod.rs
@@ -1,14 +1,18 @@
 #![allow(clippy::match_same_arms, clippy::unnested_or_patterns)]
+mod algebra;
 mod ast;
 mod polynomial;
 mod quaternion;
 
+pub use algebra::parse_algebra_expression;
 pub use polynomial::parse_integer_polynomial;
 pub use polynomial::parse_multivariate_integer_polynomial;
 pub use polynomial::parse_multivariate_rational_polynomial;
 pub use polynomial::parse_rational_polynomial;
 pub use quaternion::parse_quaternion;
 
+#[cfg(test)]
+mod algebra_tests;
 #[cfg(test)]
 mod polynomial_tests;
 #[cfg(test)]

--- a/rings/src/parsing/mod.rs
+++ b/rings/src/parsing/mod.rs
@@ -1,11 +1,15 @@
 #![allow(clippy::match_same_arms, clippy::unnested_or_patterns)]
 mod ast;
 mod polynomial;
+mod quaternion;
 
 pub use polynomial::parse_integer_polynomial;
 pub use polynomial::parse_multivariate_integer_polynomial;
 pub use polynomial::parse_multivariate_rational_polynomial;
 pub use polynomial::parse_rational_polynomial;
+pub use quaternion::parse_quaternion;
 
 #[cfg(test)]
 mod polynomial_tests;
+#[cfg(test)]
+mod quaternion_tests;

--- a/rings/src/parsing/polynomial.rs
+++ b/rings/src/parsing/polynomial.rs
@@ -11,9 +11,20 @@ use std::collections::HashMap;
 lalrpop_mod!(polynomial_parser, "/parsing/polynomial_grammar.rs");
 
 /// Parse a string into an abstract syntax tree.
-pub(super) fn parse_expression(expression_str: &str) -> Result<Expr, String> {
+///
+/// Juxtaposing a numeric coefficient with what follows it, as in "3x", is only accepted when
+/// `allow_implicit_multiplication` is set.
+pub(super) fn parse_expression(
+    expression_str: &str,
+    allow_implicit_multiplication: bool,
+) -> Result<Expr, String> {
     match polynomial_parser::ExprParser::new().parse(expression_str) {
-        Ok(expr) => Ok(*expr),
+        Ok(expr) => {
+            if !allow_implicit_multiplication && expr.contains_implicit_multiplication() {
+                return Err("Implicit multiplication is not allowed".to_string());
+            }
+            Ok(*expr)
+        }
         Err(e) => Err(format!("Failed to parse expression: {:?}", e)),
     }
 }
@@ -670,7 +681,7 @@ pub fn parse_integer_polynomial(
     polynomial_str: &str,
     var: &str,
 ) -> Result<Polynomial<Integer>, String> {
-    Expr::build_univariate_integer_polynomial(&parse_expression(polynomial_str)?, var)
+    Expr::build_univariate_integer_polynomial(&parse_expression(polynomial_str, false)?, var)
 }
 
 /// Create a polynomial with rational coefficients from a string
@@ -678,7 +689,7 @@ pub fn parse_rational_polynomial(
     polynomial_str: &str,
     var: &str,
 ) -> Result<Polynomial<Rational>, String> {
-    Expr::build_univariate_rational_polynomial(&parse_expression(polynomial_str)?, var)
+    Expr::build_univariate_rational_polynomial(&parse_expression(polynomial_str, false)?, var)
 }
 
 /// Create a multivariate polynomial with integer coefficients from a string
@@ -687,7 +698,7 @@ pub fn parse_multivariate_integer_polynomial(
     variable_mapping: HashMap<&str, Variable>,
 ) -> Result<MultiPolynomial<Integer>, String> {
     Expr::build_multivariate_integer_polynomial(
-        &parse_expression(polynomial_str)?,
+        &parse_expression(polynomial_str, false)?,
         variable_mapping,
     )
 }
@@ -698,7 +709,7 @@ pub fn parse_multivariate_rational_polynomial(
     variable_mapping: HashMap<&str, Variable>,
 ) -> Result<MultiPolynomial<Rational>, String> {
     Expr::build_multivariate_rational_polynomial(
-        &parse_expression(polynomial_str)?,
+        &parse_expression(polynomial_str, false)?,
         variable_mapping,
     )
 }

--- a/rings/src/parsing/polynomial.rs
+++ b/rings/src/parsing/polynomial.rs
@@ -10,6 +10,14 @@ use std::collections::HashMap;
 
 lalrpop_mod!(polynomial_parser, "/parsing/polynomial_grammar.rs");
 
+/// Parse a string into an abstract syntax tree.
+pub(super) fn parse_expression(expression_str: &str) -> Result<Expr, String> {
+    match polynomial_parser::ExprParser::new().parse(expression_str) {
+        Ok(expr) => Ok(*expr),
+        Err(e) => Err(format!("Failed to parse expression: {:?}", e)),
+    }
+}
+
 impl Expr {
     // pub fn from_string(input: String) -> Result<Self, String> {
     //     match polynomial_parser::ExprParser::new().parse(&input) {
@@ -662,10 +670,7 @@ pub fn parse_integer_polynomial(
     polynomial_str: &str,
     var: &str,
 ) -> Result<Polynomial<Integer>, String> {
-    match polynomial_parser::ExprParser::new().parse(polynomial_str) {
-        Ok(expr) => Expr::build_univariate_integer_polynomial(&expr, var),
-        Err(e) => Err(format!("Failed to parse expression: {:?}", e)),
-    }
+    Expr::build_univariate_integer_polynomial(&parse_expression(polynomial_str)?, var)
 }
 
 /// Create a polynomial with rational coefficients from a string
@@ -673,10 +678,7 @@ pub fn parse_rational_polynomial(
     polynomial_str: &str,
     var: &str,
 ) -> Result<Polynomial<Rational>, String> {
-    match polynomial_parser::ExprParser::new().parse(polynomial_str) {
-        Ok(expr) => Expr::build_univariate_rational_polynomial(&expr, var),
-        Err(e) => Err(format!("Failed to parse expression: {:?}", e)),
-    }
+    Expr::build_univariate_rational_polynomial(&parse_expression(polynomial_str)?, var)
 }
 
 /// Create a multivariate polynomial with integer coefficients from a string
@@ -684,10 +686,10 @@ pub fn parse_multivariate_integer_polynomial(
     polynomial_str: &str,
     variable_mapping: HashMap<&str, Variable>,
 ) -> Result<MultiPolynomial<Integer>, String> {
-    match polynomial_parser::ExprParser::new().parse(polynomial_str) {
-        Ok(expr) => Expr::build_multivariate_integer_polynomial(&expr, variable_mapping),
-        Err(e) => Err(format!("Failed to parse expression: {:?}", e)),
-    }
+    Expr::build_multivariate_integer_polynomial(
+        &parse_expression(polynomial_str)?,
+        variable_mapping,
+    )
 }
 
 /// Create a multivariate polynomial with integer coefficients from a string
@@ -695,8 +697,8 @@ pub fn parse_multivariate_rational_polynomial(
     polynomial_str: &str,
     variable_mapping: HashMap<&str, Variable>,
 ) -> Result<MultiPolynomial<Rational>, String> {
-    match polynomial_parser::ExprParser::new().parse(polynomial_str) {
-        Ok(expr) => Expr::build_multivariate_rational_polynomial(&expr, variable_mapping),
-        Err(e) => Err(format!("Failed to parse expression: {:?}", e)),
-    }
+    Expr::build_multivariate_rational_polynomial(
+        &parse_expression(polynomial_str)?,
+        variable_mapping,
+    )
 }

--- a/rings/src/parsing/polynomial_grammar.lalrpop
+++ b/rings/src/parsing/polynomial_grammar.lalrpop
@@ -26,12 +26,29 @@ SumRest: SumTerm = {
 
 Product: Box<Expr> = {
     <l:Product> "*" <r:Power> => Box::new(Expr::Product(Product { left: l, right: r })),
+    // A numeric coefficient may be juxtaposed with what follows, so that "3i" means "3*i".
+    // Only a number is allowed on the left so that "xy" remains a parse error rather than
+    // silently meaning "x*y".
+    <l:Num> <r:VarPower> => Box::new(Expr::Product(Product { left: Box::new(Expr::Num(l)), right: r })),
     Power,
 };
 
 Power: Box<Expr> = {
     <l:Atom> "^" <r:Atom> => Box::new(Expr::Power(Power { base: l, exponent: r })),
     Atom,
+};
+
+// Like `Power`, but never starting with a number or a unary minus, so that "2-x" is
+// unambiguously a subtraction and "2 3" is not a product.
+VarPower: Box<Expr> = {
+    <l:VarAtom> "^" <r:Atom> => Box::new(Expr::Power(Power { base: l, exponent: r })),
+    VarAtom,
+};
+
+VarAtom: Box<Expr> = {
+    SingleVar => Box::new(Expr::Var(<>)),
+    BracedVar => Box::new(Expr::Var(<>)),
+    "(" <e:Expr> ")" => Box::new(Expr::Grouped(e)),
 };
 
 Atom: Box<Expr> = {

--- a/rings/src/parsing/polynomial_grammar.lalrpop
+++ b/rings/src/parsing/polynomial_grammar.lalrpop
@@ -25,11 +25,11 @@ SumRest: SumTerm = {
 };
 
 Product: Box<Expr> = {
-    <l:Product> "*" <r:Power> => Box::new(Expr::Product(Product { left: l, right: r })),
+    <l:Product> "*" <r:Power> => Box::new(Expr::Product(Product { left: l, right: r, implicit: false })),
     // A numeric coefficient may be juxtaposed with what follows, so that "3i" means "3*i".
-    // Only a number is allowed on the left so that "xy" remains a parse error rather than
-    // silently meaning "x*y".
-    <l:Num> <r:VarPower> => Box::new(Expr::Product(Product { left: Box::new(Expr::Num(l)), right: r })),
+    // Only a number is allowed on the left so that "xy" is not silently read as "x*y". Whether
+    // this is accepted is up to the caller, see `parse_expression`.
+    <l:Num> <r:VarPower> => Box::new(Expr::Product(Product { left: Box::new(Expr::Num(l)), right: r, implicit: true })),
     Power,
 };
 

--- a/rings/src/parsing/polynomial_tests.rs
+++ b/rings/src/parsing/polynomial_tests.rs
@@ -383,11 +383,35 @@ fn test_invalid_polynomial() {
 }
 
 #[test]
-fn test_invalid_implicit_multiplication() {
-    // These should fail because implicit multiplication is not allowed
-    let result = parse_rational_polynomial("2x", "x");
-    assert!(result.is_err());
+fn test_numeric_implicit_multiplication() {
+    // A number may be juxtaposed with what follows it
+    let result = parse_rational_polynomial("2x", "x").unwrap();
+    assert_eq!(
+        result,
+        Polynomial::from_coeffs(vec![Rational::from(0), Rational::from(2)])
+    );
 
+    let result = parse_rational_polynomial("2x^2 - 3(x + 1)", "x").unwrap();
+    assert_eq!(
+        result,
+        Polynomial::from_coeffs(vec![
+            Rational::from(-3),
+            Rational::from(-3),
+            Rational::from(2)
+        ])
+    );
+
+    // Subtraction is not implicit multiplication by a negative number
+    let result = parse_rational_polynomial("2 - x", "x").unwrap();
+    assert_eq!(
+        result,
+        Polynomial::from_coeffs(vec![Rational::from(2), Rational::from(-1)])
+    );
+}
+
+#[test]
+fn test_invalid_implicit_multiplication() {
+    // These should fail because implicit multiplication is only allowed after a number
     let result = parse_rational_polynomial("xy", "x");
     assert!(result.is_err());
 
@@ -398,10 +422,6 @@ fn test_invalid_implicit_multiplication() {
     // so we can use empty variable mappings
     let empty_mapping = HashMap::new();
 
-    let result = parse_multivariate_rational_polynomial("2x", empty_mapping);
-    assert!(result.is_err());
-
-    let empty_mapping = HashMap::new();
     let result = parse_multivariate_rational_polynomial("x{foo}", empty_mapping);
     assert!(result.is_err());
 }

--- a/rings/src/parsing/polynomial_tests.rs
+++ b/rings/src/parsing/polynomial_tests.rs
@@ -383,35 +383,11 @@ fn test_invalid_polynomial() {
 }
 
 #[test]
-fn test_numeric_implicit_multiplication() {
-    // A number may be juxtaposed with what follows it
-    let result = parse_rational_polynomial("2x", "x").unwrap();
-    assert_eq!(
-        result,
-        Polynomial::from_coeffs(vec![Rational::from(0), Rational::from(2)])
-    );
-
-    let result = parse_rational_polynomial("2x^2 - 3(x + 1)", "x").unwrap();
-    assert_eq!(
-        result,
-        Polynomial::from_coeffs(vec![
-            Rational::from(-3),
-            Rational::from(-3),
-            Rational::from(2)
-        ])
-    );
-
-    // Subtraction is not implicit multiplication by a negative number
-    let result = parse_rational_polynomial("2 - x", "x").unwrap();
-    assert_eq!(
-        result,
-        Polynomial::from_coeffs(vec![Rational::from(2), Rational::from(-1)])
-    );
-}
-
-#[test]
 fn test_invalid_implicit_multiplication() {
-    // These should fail because implicit multiplication is only allowed after a number
+    // These should fail because implicit multiplication is not allowed
+    let result = parse_rational_polynomial("2x", "x");
+    assert!(result.is_err());
+
     let result = parse_rational_polynomial("xy", "x");
     assert!(result.is_err());
 
@@ -422,6 +398,10 @@ fn test_invalid_implicit_multiplication() {
     // so we can use empty variable mappings
     let empty_mapping = HashMap::new();
 
+    let result = parse_multivariate_rational_polynomial("2x", empty_mapping);
+    assert!(result.is_err());
+
+    let empty_mapping = HashMap::new();
     let result = parse_multivariate_rational_polynomial("x{foo}", empty_mapping);
     assert!(result.is_err());
 }

--- a/rings/src/parsing/quaternion.rs
+++ b/rings/src/parsing/quaternion.rs
@@ -1,0 +1,85 @@
+use crate::parsing::polynomial::parse_multivariate_rational_polynomial;
+use crate::polynomial::Variable;
+use crate::quaternion_algebra::{QuaternionAlgebraElement, QuaternionAlgebraStructure};
+use crate::structure::{FieldSignature, SemiModuleSignature};
+use algebraeon_structures::*;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Create an element of a quaternion algebra from a string such as `"2 + 3i + 5j - 2k"`.
+///
+/// The expression must be linear in `i`, `j` and `k`, since the quaternion algebra is not
+/// commutative and so, for example, `i*j` is not determined by the parsed expression alone.
+///
+/// ```
+/// use algebraeon_rings::parsing::parse_quaternion;
+/// use algebraeon_rings::quaternion_algebra::QuaternionAlgebraStructure;
+/// use algebraeon_rings::structure::*;
+/// use algebraeon_structures::*;
+///
+/// // Hamilton quaternion algebra: H = (-1, -1 / QQ)
+/// let h = QuaternionAlgebraStructure::new(Rational::structure(), -Rational::ONE, -Rational::ONE);
+/// let q = parse_quaternion("2+3i+5j-2k", &h).unwrap();
+/// let expected = h.from_components(
+///     Rational::from(2),
+///     Rational::from(3),
+///     Rational::from(5),
+///     Rational::from(-2),
+/// );
+/// assert!(h.equal(&q, &expected));
+/// ```
+pub fn parse_quaternion<Field: FieldSignature>(
+    quaternion_str: &str,
+    quaternion_algebra: &Arc<QuaternionAlgebraStructure<Field>>,
+) -> Result<QuaternionAlgebraElement<Field::Elem>, String> {
+    let i_var = Variable::new("i");
+    let j_var = Variable::new("j");
+    let k_var = Variable::new("k");
+    let variable_mapping = HashMap::from([
+        ("i", i_var.clone()),
+        ("j", j_var.clone()),
+        ("k", k_var.clone()),
+    ]);
+
+    let polynomial = parse_multivariate_rational_polynomial(quaternion_str, variable_mapping)?;
+
+    // The coefficients of 1, i, j and k.
+    let mut components = [
+        Rational::ZERO,
+        Rational::ZERO,
+        Rational::ZERO,
+        Rational::ZERO,
+    ];
+    for term in &polynomial.terms {
+        let monomial = &term.monomial;
+        let component = match monomial.degree() {
+            0 => 0,
+            1 => {
+                if monomial.get_var_pow(&i_var) == 1 {
+                    1
+                } else if monomial.get_var_pow(&j_var) == 1 {
+                    2
+                } else {
+                    debug_assert_eq!(monomial.get_var_pow(&k_var), 1);
+                    3
+                }
+            }
+            _ => {
+                return Err(format!(
+                    "Quaternion expressions must be linear in i, j and k, but found the term '{}'",
+                    monomial
+                ));
+            }
+        };
+        components[component] += term.coeff.clone();
+    }
+
+    let base_field = quaternion_algebra.ring();
+    let [x, y, z, w] = components.map(|c| {
+        base_field
+            .try_from_rat(&c)
+            .ok_or_else(|| format!("No element of the base field is equal to {}", c))
+    });
+
+    Ok(quaternion_algebra.from_components(x?, y?, z?, w?))
+}

--- a/rings/src/parsing/quaternion.rs
+++ b/rings/src/parsing/quaternion.rs
@@ -1,15 +1,13 @@
-use crate::parsing::polynomial::parse_multivariate_rational_polynomial;
-use crate::polynomial::Variable;
+use crate::parsing::algebra::parse_algebra_expression;
 use crate::quaternion_algebra::{QuaternionAlgebraElement, QuaternionAlgebraStructure};
-use crate::structure::{FieldSignature, SemiModuleSignature};
-use algebraeon_structures::*;
+use crate::structure::FieldSignature;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Create an element of a quaternion algebra from a string such as `"2 + 3i + 5j - 2k"`.
 ///
-/// The expression must be linear in `i`, `j` and `k`, since the quaternion algebra is not
-/// commutative and so, for example, `i*j` is not determined by the parsed expression alone.
+/// The order of the factors of each product is respected, so `"i*j"` and `"j*i"` give different
+/// elements.
 ///
 /// ```
 /// use algebraeon_rings::parsing::parse_quaternion;
@@ -27,59 +25,20 @@ use std::sync::Arc;
 ///     Rational::from(-2),
 /// );
 /// assert!(h.equal(&q, &expected));
+///
+/// // ij = k and ji = -k
+/// let ij = parse_quaternion("i*j", &h).unwrap();
+/// assert!(h.equal(&ij, &h.k()));
+/// assert!(h.equal(&parse_quaternion("j*i", &h).unwrap(), &h.neg(&ij)));
 /// ```
 pub fn parse_quaternion<Field: FieldSignature>(
     quaternion_str: &str,
     quaternion_algebra: &Arc<QuaternionAlgebraStructure<Field>>,
 ) -> Result<QuaternionAlgebraElement<Field::Elem>, String> {
-    let i_var = Variable::new("i");
-    let j_var = Variable::new("j");
-    let k_var = Variable::new("k");
-    let variable_mapping = HashMap::from([
-        ("i", i_var.clone()),
-        ("j", j_var.clone()),
-        ("k", k_var.clone()),
+    let variables = HashMap::from([
+        ("i", quaternion_algebra.i()),
+        ("j", quaternion_algebra.j()),
+        ("k", quaternion_algebra.k()),
     ]);
-
-    let polynomial = parse_multivariate_rational_polynomial(quaternion_str, variable_mapping)?;
-
-    // The coefficients of 1, i, j and k.
-    let mut components = [
-        Rational::ZERO,
-        Rational::ZERO,
-        Rational::ZERO,
-        Rational::ZERO,
-    ];
-    for term in &polynomial.terms {
-        let monomial = &term.monomial;
-        let component = match monomial.degree() {
-            0 => 0,
-            1 => {
-                if monomial.get_var_pow(&i_var) == 1 {
-                    1
-                } else if monomial.get_var_pow(&j_var) == 1 {
-                    2
-                } else {
-                    debug_assert_eq!(monomial.get_var_pow(&k_var), 1);
-                    3
-                }
-            }
-            _ => {
-                return Err(format!(
-                    "Quaternion expressions must be linear in i, j and k, but found the term '{}'",
-                    monomial
-                ));
-            }
-        };
-        components[component] += term.coeff.clone();
-    }
-
-    let base_field = quaternion_algebra.ring();
-    let [x, y, z, w] = components.map(|c| {
-        base_field
-            .try_from_rat(&c)
-            .ok_or_else(|| format!("No element of the base field is equal to {}", c))
-    });
-
-    Ok(quaternion_algebra.from_components(x?, y?, z?, w?))
+    parse_algebra_expression(quaternion_str, quaternion_algebra, &variables)
 }

--- a/rings/src/parsing/quaternion_tests.rs
+++ b/rings/src/parsing/quaternion_tests.rs
@@ -1,0 +1,106 @@
+use crate::finite_fields::conway_finite_fields::ConwayFiniteFieldStructure;
+use crate::parsing::parse_quaternion;
+use crate::quaternion_algebra::{QuaternionAlgebraElement, QuaternionAlgebraStructure};
+use crate::structure::*;
+use algebraeon_structures::*;
+use std::sync::Arc;
+
+/// Hamilton quaternion algebra: H = (-1, -1 / QQ)
+fn hamilton() -> Arc<QuaternionAlgebraStructure<RationalCanonicalStructure>> {
+    QuaternionAlgebraStructure::new(Rational::structure(), -Rational::ONE, -Rational::ONE)
+}
+
+fn quaternion(
+    h: &Arc<QuaternionAlgebraStructure<RationalCanonicalStructure>>,
+    x: i32,
+    y: i32,
+    z: i32,
+    w: i32,
+) -> QuaternionAlgebraElement<Rational> {
+    h.from_components(
+        Rational::from(x),
+        Rational::from(y),
+        Rational::from(z),
+        Rational::from(w),
+    )
+}
+
+#[test]
+fn test_parse_quaternion_implicit_multiplication() {
+    let h = hamilton();
+    let q = parse_quaternion("2+3i+5j-2k", &h).unwrap();
+    assert!(h.equal(&q, &quaternion(&h, 2, 3, 5, -2)));
+}
+
+#[test]
+fn test_parse_quaternion_explicit_multiplication() {
+    let h = hamilton();
+    let q = parse_quaternion("2 + 3*i + 5*j - 2*k", &h).unwrap();
+    assert!(h.equal(&q, &quaternion(&h, 2, 3, 5, -2)));
+}
+
+#[test]
+fn test_parse_quaternion_basis_elements() {
+    let h = hamilton();
+    assert!(h.equal(&parse_quaternion("1", &h).unwrap(), &h.one()));
+    assert!(h.equal(&parse_quaternion("i", &h).unwrap(), &h.i()));
+    assert!(h.equal(&parse_quaternion("j", &h).unwrap(), &h.j()));
+    assert!(h.equal(&parse_quaternion("k", &h).unwrap(), &h.k()));
+    assert!(h.equal(&parse_quaternion("-i", &h).unwrap(), &h.neg(&h.i())));
+}
+
+#[test]
+fn test_parse_quaternion_rational_coefficients() {
+    let h = hamilton();
+    let q = parse_quaternion("1/3 - 1/5*i + 1/7j - k", &h).unwrap();
+    let expected = h.from_components(
+        Rational::from_integers(1, 3),
+        -Rational::from_integers(1, 5),
+        Rational::from_integers(1, 7),
+        -Rational::ONE,
+    );
+    assert!(h.equal(&q, &expected));
+}
+
+#[test]
+fn test_parse_quaternion_collects_repeated_terms() {
+    let h = hamilton();
+    let q = parse_quaternion("i + 2 + 3i - 2", &h).unwrap();
+    assert!(h.equal(&q, &quaternion(&h, 0, 4, 0, 0)));
+}
+
+#[test]
+fn test_parse_quaternion_expands_brackets() {
+    let h = hamilton();
+    let q = parse_quaternion("2*(1 + i) - 3(j - k)", &h).unwrap();
+    assert!(h.equal(&q, &quaternion(&h, 2, 2, -3, 3)));
+}
+
+#[test]
+fn test_parse_quaternion_over_finite_field() {
+    let f5 = ConwayFiniteFieldStructure::new(5, 1).unwrap();
+    let algebra = QuaternionAlgebraStructure::new(f5.clone(), f5.from_int(2), f5.from_int(3));
+    // 7 = 2 and 1/2 = 3 modulo 5
+    let q = parse_quaternion("7 + 1/2*i", &algebra).unwrap();
+    let expected = algebra.from_components(f5.from_int(2), f5.from_int(3), f5.zero(), f5.zero());
+    assert!(algebra.equal(&q, &expected));
+}
+
+#[test]
+fn test_parse_quaternion_nonlinear() {
+    let h = hamilton();
+    // i*j is not determined by the commutative polynomial i*j, so it is rejected
+    assert!(parse_quaternion("i*j", &h).is_err());
+    assert!(parse_quaternion("i^2", &h).is_err());
+    assert!(parse_quaternion("(1 + i)*(1 + j)", &h).is_err());
+}
+
+#[test]
+fn test_parse_quaternion_invalid() {
+    let h = hamilton();
+    // only i, j and k are valid variables
+    assert!(parse_quaternion("1 + x", &h).is_err());
+    // implicit multiplication of two variables is still not allowed
+    assert!(parse_quaternion("ij", &h).is_err());
+    assert!(parse_quaternion("1 +", &h).is_err());
+}

--- a/rings/src/parsing/quaternion_tests.rs
+++ b/rings/src/parsing/quaternion_tests.rs
@@ -87,12 +87,46 @@ fn test_parse_quaternion_over_finite_field() {
 }
 
 #[test]
-fn test_parse_quaternion_nonlinear() {
+fn test_parse_quaternion_products_are_not_commutative() {
     let h = hamilton();
-    // i*j is not determined by the commutative polynomial i*j, so it is rejected
-    assert!(parse_quaternion("i*j", &h).is_err());
-    assert!(parse_quaternion("i^2", &h).is_err());
-    assert!(parse_quaternion("(1 + i)*(1 + j)", &h).is_err());
+    let ij = parse_quaternion("i*j", &h).unwrap();
+    let ji = parse_quaternion("j*i", &h).unwrap();
+    assert!(h.equal(&ij, &h.k()));
+    assert!(h.equal(&ji, &h.neg(&h.k())));
+}
+
+#[test]
+fn test_parse_quaternion_powers() {
+    let h = hamilton();
+    // i^2 = j^2 = k^2 = -1 in the Hamilton quaternions
+    assert!(h.equal(&parse_quaternion("i^2", &h).unwrap(), &h.neg(&h.one())));
+    assert!(h.equal(&parse_quaternion("j^2", &h).unwrap(), &h.neg(&h.one())));
+    assert!(h.equal(&parse_quaternion("k^2", &h).unwrap(), &h.neg(&h.one())));
+    assert!(h.equal(&parse_quaternion("i^0", &h).unwrap(), &h.one()));
+    // (1 + i)^2 = 1 + 2i + i^2 = 2i
+    assert!(h.equal(
+        &parse_quaternion("(1 + i)^2", &h).unwrap(),
+        &quaternion(&h, 0, 2, 0, 0)
+    ));
+}
+
+#[test]
+fn test_parse_quaternion_expands_products() {
+    let h = hamilton();
+    // (1 + i)*(1 + j) = 1 + i + j + ij = 1 + i + j + k
+    let q = parse_quaternion("(1 + i)*(1 + j)", &h).unwrap();
+    assert!(h.equal(&q, &quaternion(&h, 1, 1, 1, 1)));
+}
+
+#[test]
+fn test_parse_quaternion_linear_in_characteristic_two() {
+    // Multiplication in characteristic 2 is not implemented, but expressions which are linear in
+    // i, j and k only need scalar multiplication
+    let f2 = ConwayFiniteFieldStructure::new(2, 1).unwrap();
+    let algebra = QuaternionAlgebraStructure::new(f2.clone(), f2.from_int(1), f2.from_int(1));
+    let q = parse_quaternion("3 + 2i + j", &algebra).unwrap();
+    let expected = algebra.from_components(f2.one(), f2.zero(), f2.one(), f2.zero());
+    assert!(algebra.equal(&q, &expected));
 }
 
 #[test]
@@ -100,6 +134,10 @@ fn test_parse_quaternion_invalid() {
     let h = hamilton();
     // only i, j and k are valid variables
     assert!(parse_quaternion("1 + x", &h).is_err());
+    // division and negative or fractional exponents are not supported
+    assert!(parse_quaternion("1/(1 + i)", &h).is_err());
+    assert!(parse_quaternion("i^-1", &h).is_err());
+    assert!(parse_quaternion("i^(1/2)", &h).is_err());
     // implicit multiplication of two variables is still not allowed
     assert!(parse_quaternion("ij", &h).is_err());
     assert!(parse_quaternion("1 +", &h).is_err());

--- a/rings/src/quaternion_algebra/mod.rs
+++ b/rings/src/quaternion_algebra/mod.rs
@@ -346,6 +346,17 @@ impl<Field: CharZeroFieldSignature> CharZeroRingSignature for QuaternionAlgebraS
 }
 
 impl<Field: FieldSignature> QuaternionAlgebraStructure<Field> {
+    /// The element `x + y*i + z*j + w*k`.
+    pub fn from_components(
+        &self,
+        x: Field::Elem,
+        y: Field::Elem,
+        z: Field::Elem,
+        w: Field::Elem,
+    ) -> QuaternionAlgebraElement<Field::Elem> {
+        QuaternionAlgebraElement { x, y, z, w }
+    }
+
     pub fn i(&self) -> QuaternionAlgebraElement<Field::Elem> {
         QuaternionAlgebraElement {
             x: self.base.zero(),


### PR DESCRIPTION
Add `parse_quaternion`, which builds an element of a quaternion algebra
from a string such as "2+3i+5j-2k" by parsing it as a multivariate
rational polynomial in i, j and k.

Closes #174